### PR TITLE
Parse database value to int for strict comparison

### DIFF
--- a/src/services/Redirects.php
+++ b/src/services/Redirects.php
@@ -435,7 +435,7 @@ class Redirects extends Component
             ->scalar();
 
         // Don't delete the 404 if we're currently updating it
-        if (!$existing404RedirectId || $existing404RedirectId === $redirect->id) {
+        if (!$existing404RedirectId || intval($existing404RedirectId) === $redirect->id) {
             return;
         }
         


### PR DESCRIPTION
When updating any redirect, it's always deleted: traced to this strict comparison always failing since the database value comes out as a string.

Dev: PHP 7.3.9 / MySQL 5.7.26 + Prod: PHP 7.0.33 / MySQL 5.7.32